### PR TITLE
A small fix to the shaders

### DIFF
--- a/src/warp.frag
+++ b/src/warp.frag
@@ -28,4 +28,4 @@ void main(void)
 	} else {
 		gl_FragColor = texture2D(WarpTexture, tc);
 	}
-};
+}

--- a/src/warpWithChromeAb.frag
+++ b/src/warpWithChromeAb.frag
@@ -35,4 +35,4 @@ void main(void)
 	vec2 tcRed = LensCenter + Scale * thetaRed;
 	float red = texture2D(WarpTexture, tcRed).r;
 	gl_FragColor = vec4(red, green, blue, 1);
-};
+}


### PR DESCRIPTION
I found that the trailing semi colons in the fragment shaders caused errors like these when they were loaded:

FRAGMENT glCompileShader "" FAILED
FRAGMENT Shader "" infolog:
ERROR: 0:38: ';' : syntax error syntax error

I'm not sure why I'd be the only one to get them but I suppose it might have something to do with differences between our graphics cards and/or the drivers.
