### PR TITLE
Switched order of opengl dependency libraries in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,14 +38,14 @@ ADD_LIBRARY(${TARGET_LIBRARYNAME} ${TARGET_SRC} ${TARGET_H})
 # Linker options
 #####################################################################
 
-# Link to open gl libs
-TARGET_LINK_LIBRARIES(${TARGET_LIBRARYNAME} ${OPENGL_LIBRARIES} )
-
 # Link to OpenSceneGraph libs
 TARGET_LINK_LIBRARIES(${TARGET_LIBRARYNAME} ${OPENSCENEGRAPH_LIBRARIES} )
 
 # Link to Oculus libs
 TARGET_LINK_LIBRARIES(${TARGET_LIBRARYNAME} ${OCULUS_SDK_LIBRARIES}	)
+
+# Link to open gl libs
+TARGET_LINK_LIBRARIES(${TARGET_LIBRARYNAME} ${OPENGL_LIBRARIES} )
 
 # Link to libraries needed for Oculus on Visual Studio
 IF(MSVC)


### PR DESCRIPTION
Had to do this to compile on my Ubuntu 14.04 comp.
Because OpenSceneGraph and Oculus depend on OpenGL, they must be passed to the linker before OpenGL.
