### PR TITLE
OculusDevice accessor & mirror example

### DIFF
--- a/src/oculusviewconfig.h
+++ b/src/oculusviewconfig.h
@@ -21,6 +21,9 @@ class OculusViewConfig : public osgViewer::ViewConfig {
 		}
 		void setSceneNodeMask(osg::Node::NodeMask nodeMask) { m_sceneNodeMask = nodeMask; }
 		virtual void configure(osgViewer::View& view) const;
+
+      OculusDevice* getOculusDevice(){ return m_device.get(); }
+
 	protected:
 		~OculusViewConfig() {};
 

--- a/src/viewconfigexample.cpp
+++ b/src/viewconfigexample.cpp
@@ -11,6 +11,48 @@
 #include "oculuseventhandler.h"
 #include "oculusviewconfig.h"
 
+#include <osg/Camera>
+
+
+// Update callback for the camera which "mirrors" the view inside the oculus,
+// matching its tracked position
+class MirrorViewCallback : public osg::NodeCallback {
+public:
+   MirrorViewCallback(osg::Camera* mirrorCamera, OculusDevice* oculus) :
+      mMirrorCamera(mirrorCamera),
+      mOculusDevice(oculus)
+   {}
+
+   virtual void operator() (osg::Node* node, osg::NodeVisitor* nv)
+   {
+      osg::View* view = mMirrorCamera->getView();
+
+      if (view) {
+         
+         osg::Vec3 position = mOculusDevice.get()->position();
+         osg::Quat orientation = mOculusDevice.get()->orientation();
+         osg::Matrix viewMx;
+         
+         viewMx.preMultRotate(orientation);
+         viewMx.preMultTranslate(position);
+         
+         // Nasty hack to update the view offset for each of the slave cameras
+         // There doesn't seem to be an accessor for this, fortunately the offsets are public
+         view->findSlaveForCamera(mMirrorCamera.get())->_viewOffset = viewMx;         
+      }
+
+      traverse(node, nv);
+   }
+
+protected:
+   osg::observer_ptr<osg::Camera> mMirrorCamera;
+   osg::observer_ptr<OculusDevice> mOculusDevice;
+};
+
+
+
+
+
 int main( int argc, char** argv )
 {
 	// use an ArgumentParser object to manage the program arguments.
@@ -41,6 +83,51 @@ int main( int argc, char** argv )
 	viewer.addEventHandler(new osgViewer::StatsHandler);
 	// Apply view config
 	viewer.apply(oculusViewConfig);
+
+
+   
+   if (arguments.find("--mirror") != -1)
+   {
+      // read the screen id where to create the mirror window, 0 by default
+      int screenId = 0;
+      arguments.read("--mirror", screenId);
+
+      // create a window with an aspect ratio consistent with the main camera,
+      // based on its projection matrix
+      float fovy, ar, znear, zfar;
+      viewer.getCamera()->getProjectionMatrix().getPerspective(fovy, ar, znear, zfar);
+      int mirrorWidth = 800;
+      int mirrorHeight = (float)mirrorWidth / ar;
+
+      // render the view on a mirror window as well
+      osg::ref_ptr<osg::GraphicsContext::Traits> traits = new osg::GraphicsContext::Traits;
+      traits->screenNum = screenId;
+      traits->x = 100;
+      traits->y = 100;
+      traits->width = mirrorWidth;
+      traits->height = mirrorHeight;
+      traits->windowDecoration = true;
+      traits->doubleBuffer = true;
+      traits->sharedContext = 0;
+
+      osg::ref_ptr<osg::GraphicsContext> gc = osg::GraphicsContext::createGraphicsContext(traits.get());
+      if (!gc.valid())
+      {
+         OSG_ALWAYS << "[Mirror View] Could NOT create the mirror GraphicsWindow successfully on screen number: " << screenId << std::endl;
+      }
+
+      osg::Camera* mirrorCam = new osg::Camera;
+      mirrorCam->setGraphicsContext(gc.get());
+      mirrorCam->setViewport(new osg::Viewport(0, 0, mirrorWidth, mirrorHeight));
+      mirrorCam->setCullMask(0xffffffff);
+
+      // add as slave
+      viewer.addSlave(mirrorCam);
+      // update callback to match the oculus tracked camera, without any eye offset
+      mirrorCam->setUpdateCallback(new MirrorViewCallback(mirrorCam, oculusViewConfig->getOculusDevice()));
+   }
+
+
 	// Add loaded model to viewer
 	viewer.setSceneData(loadedModel);
 	// Start Viewer


### PR DESCRIPTION
OculusViewConfig: added accessor for the OculusDevice
ViewConfigExample: added an option to create a window on another screen which mirrors the view inside the oculus