### PR TITLE
Support for viewing scenes with world units not in meters.

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -135,7 +135,8 @@ const std::string OculusDevice::m_warpFragmentShaderSource(
 
 
 /* Public functions */
-OculusDevice::OculusDevice(float nearClip, float farClip, float pixelsPerDisplayPixel, bool useTimewarp) : m_hmdDevice(0),
+OculusDevice::OculusDevice(float nearClip, float farClip, float pixelsPerDisplayPixel, bool useTimewarp, float worldUnitsPerMetre) : m_hmdDevice(0),
+m_worldUnitsPerMetre(worldUnitsPerMetre),
 m_position(osg::Vec3(0.0f, 0.0f, 0.0f)),
 m_orientation(osg::Quat(0.0f, 0.0f, 0.0f, 1.0f)),
 m_nearClip(nearClip), m_farClip(farClip),
@@ -280,6 +281,7 @@ void OculusDevice::updatePose(unsigned int frameIndex)
 	ovrPoseStatef headpose = ts.HeadPose;
 	ovrPosef pose = headpose.ThePose;
 	m_position.set(-pose.Position.x, -pose.Position.y, -pose.Position.z);
+	m_position *= m_worldUnitsPerMetre;
 	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, -pose.Orientation.w);
 
 	// Get head pose for both eyes (used for time warp
@@ -639,8 +641,10 @@ void OculusDevice::initializeEyeRenderDesc() {
 void OculusDevice::calculateEyeAdjustment() {
 	ovrVector3f leftEyeAdjust = m_eyeRenderDesc[0].HmdToEyeViewOffset;
 	m_leftEyeAdjust.set(leftEyeAdjust.x, leftEyeAdjust.y, leftEyeAdjust.z);
+	m_leftEyeAdjust *= m_worldUnitsPerMetre;
 	ovrVector3f rightEyeAdjust = m_eyeRenderDesc[1].HmdToEyeViewOffset;
 	m_rightEyeAdjust.set(rightEyeAdjust.x, rightEyeAdjust.y, rightEyeAdjust.z);
+	m_rightEyeAdjust *= m_worldUnitsPerMetre;
 }
 
 void OculusDevice::calculateProjectionMatrices() {

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -32,7 +32,7 @@ class OculusDevice : public osg::Referenced {
 			RIGHT = 1,
 			COUNT = 2
 		};
-		OculusDevice(float nearClip, float farClip, float pixelsPerDisplayPixel, bool useTimewarp);
+		OculusDevice(float nearClip, float farClip, float pixelsPerDisplayPixel, bool useTimewarp, float worldUnitsPerMetre = 1.0f);
 
 		unsigned int screenResolutionWidth() const;
 		unsigned int screenResolutionHeight() const;
@@ -114,6 +114,7 @@ class OculusDevice : public osg::Referenced {
 		osg::Vec3f m_leftEyeAdjust;
 		osg::Vec3f m_rightEyeAdjust;
 
+		float m_worldUnitsPerMetre; 
 		osg::Vec3 m_position;
 		osg::Quat m_orientation;
 

--- a/src/oculusviewconfig.h
+++ b/src/oculusviewconfig.h
@@ -15,12 +15,12 @@
 
 class OculusViewConfig : public osgViewer::ViewConfig {
 	public:
-		OculusViewConfig(float nearClip=0.01f, float farClip=10000.0f, float pixelsPerDisplayPixel=1.0f, bool useTimewarp=true) : osgViewer::ViewConfig(),
+		OculusViewConfig(float nearClip=0.01f, float farClip=10000.0f, float pixelsPerDisplayPixel=1.0f, bool useTimewarp=true, float worldUnitsPerMetre = 1.0f) : osgViewer::ViewConfig(),
 			m_configured(false),
 			m_sceneNodeMask(0x1),
 			m_device(0),
 			m_warning(0) {
-			m_device = new OculusDevice(nearClip, farClip, pixelsPerDisplayPixel, useTimewarp);
+			m_device = new OculusDevice(nearClip, farClip, pixelsPerDisplayPixel, useTimewarp, worldUnitsPerMetre);
 			m_warning = new OculusHealthAndSafetyWarning(m_device);
 		}
 		void setSceneNodeMask(osg::Node::NodeMask nodeMask) { m_sceneNodeMask = nodeMask; }

--- a/src/viewconfigexample.cpp
+++ b/src/viewconfigexample.cpp
@@ -50,8 +50,10 @@ int main( int argc, char** argv )
 	// Create Oculus View Config
 	float nearClip = 0.01f;
 	float farClip = 10000.0f;
+	float pixelsPerDisplayPixel = 1.0f;
 	bool useTimewarp = true;
-	osg::ref_ptr<OculusViewConfig> oculusViewConfig = new OculusViewConfig(nearClip, farClip, useTimewarp);
+	float worldUnitsPerMetre = 1.0f;
+	osg::ref_ptr<OculusViewConfig> oculusViewConfig = new OculusViewConfig(nearClip, farClip, pixelsPerDisplayPixel, useTimewarp, worldUnitsPerMetre);
 	// Add health and safety warning
 	root->addChild(oculusViewConfig->warning()->getGraph());
 	// Set the node mask used for scene


### PR DESCRIPTION
Firstly, many thanks for making this open source project! Great work.

This pull request contains a small change that solves a problem that had me foxed for a while.

The problem was that when viewing my scenes with oculus, the perceived distances looked wrong and the head position tracking did not seem to be working at all. After some investigation I realized that my scenes were using millimeter world units and so was not matching up with meter units that oculus provides for head tracking position and eye separation.

So, this pull request simply allows you to pass in a scale factor (defaulting to 1.0) to allow adjustment of  the slave camera offsets to match the world units of the scene.

BTW. This request also contains a correction to viewerconfigexample.cpp which passed in useTimeWarp variable as the pixelsPerDisplayPixel parameter of the OculusViewConfig constructor.

Thanks.
Chris. 

