### PR TITLE
Fix for memory leak of index array used to create distortion mesh.

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -327,7 +327,7 @@ osg::Geode* OculusDevice::distortionMesh(Eye eye, osg::Program* program, int x, 
 	}
 
 	// Get triangle indicies 
-	osg::UShortArray* indexArray = new osg::UShortArray;
+	osg::ref_ptr<osg::UShortArray> indexArray = new osg::UShortArray;
 	unsigned short* index = meshData.pIndexData;
 	for (unsigned indexNum = 0; indexNum < meshData.IndexCount; ++indexNum) {
 		indexArray->push_back(index[indexNum]);


### PR DESCRIPTION
I think the index array used to create the distortion mesh must be copied rather than referenced, so this change just uses osg::ref_ptr to make sure it is released.