### PR TITLE
Make slave cameras inherit the clear colour of the main camera.

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -344,12 +344,12 @@ void OculusDevice::updatePose(unsigned int frameIndex)
 	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, -pose.Orientation.w);
 }
 
-osg::Camera* OculusDevice::createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, osg::GraphicsContext* gc) const
+osg::Camera* OculusDevice::createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, const osg::Vec4& clearColor, osg::GraphicsContext* gc) const
 {
 	osg::Texture2D* texture = m_textureBuffer[renderOrder(eye)]->texture();
 	osg::Texture2D* depth = m_depthBuffer[renderOrder(eye)]->texture();
 	osg::ref_ptr<osg::Camera> camera = new osg::Camera;
-	camera->setClearColor(osg::Vec4(0.2f, 0.2f, 0.4f, 1.0f));
+	camera->setClearColor(clearColor);
 	camera->setClearMask(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	camera->setRenderTargetImplementation(osg::Camera::FRAME_BUFFER_OBJECT);
 	camera->setRenderOrder(osg::Camera::PRE_RENDER, renderOrder(eye));

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -144,7 +144,7 @@ class OculusDevice : public osg::Referenced {
 		osg::Vec3 position() const { return m_position; }
 		osg::Quat orientation() const { return m_orientation;  }
 
-		osg::Camera* createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, osg::GraphicsContext* gc = 0) const;
+		osg::Camera* createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, const osg::Vec4& clearColor, osg::GraphicsContext* gc = 0) const;
 		
 		bool submitFrame(unsigned int frameIndex = 0);
 		void blitMirrorTexture(osg::GraphicsContext *gc);

--- a/src/oculusviewer.cpp
+++ b/src/oculusviewer.cpp
@@ -33,11 +33,13 @@ void OculusViewer::configure()
 
 	osg::ref_ptr<osg::Camera> camera = m_view->getCamera();
 	camera->setName("Main");
+	osg::Vec4 clearColor = camera->getClearColor();
+
 	// master projection matrix
 	camera->setProjectionMatrix(m_device->projectionMatrixCenter());
 	// Create RTT cameras and attach textures
-	m_cameraRTTLeft = m_device->createRTTCamera(OculusDevice::LEFT, osg::Camera::RELATIVE_RF, gc);
-	m_cameraRTTRight = m_device->createRTTCamera(OculusDevice::RIGHT, osg::Camera::RELATIVE_RF, gc);
+	m_cameraRTTLeft = m_device->createRTTCamera(OculusDevice::LEFT, osg::Camera::RELATIVE_RF, clearColor, gc);
+	m_cameraRTTRight = m_device->createRTTCamera(OculusDevice::RIGHT, osg::Camera::RELATIVE_RF, clearColor, gc);
 	m_cameraRTTLeft->setName("LeftRTT");
 	m_cameraRTTRight->setName("RightRTT");
 


### PR DESCRIPTION
The `clearColor` of the slave cameras was hard coded, so this pull request sets the `clearColor` of the slave cameras to match the main camera, so the color can then be set outside the osgoculusviewer code.