### PR TITLE
Adding MSAA support.

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -31,6 +31,15 @@ static const OSG_GLExtensions* getGLExtensions(const osg::State& state)
 #endif
 }
 
+static const OSG_Texture_Extensions* getTextureExtensions(const osg::State& state)
+{
+#if(OSG_VERSION_GREATER_OR_EQUAL(3, 4, 0))
+	return state.get<osg::GLExtensions>();
+#else
+	return osg::Texture::getExtensions(state.getContextID(), true);
+#endif
+}
+
 static osg::FrameBufferObject* getFrameBufferObject(osg::RenderInfo& renderInfo)
 {
 	osg::Camera* camera = renderInfo.getCurrentCamera();
@@ -70,16 +79,16 @@ m_samples(samples)
 {
 	if (samples == 0)
 	{
-		SetupNormal(*state);
+		setup(*state);
 	}
 	else
 	{
-		SetupMSAA(*state);
+		setupMSAA(*state);
 	}
 
 }
 
-void OculusTextureBuffer::SetupNormal(osg::State& state)
+void OculusTextureBuffer::setup(osg::State& state)
 {
 	if (ovr_CreateSwapTextureSetGL(m_hmdDevice, GL_SRGB8_ALPHA8, textureWidth(), textureHeight(), &m_textureSet) == ovrSuccess) 
 	{
@@ -133,7 +142,7 @@ void OculusTextureBuffer::SetupNormal(osg::State& state)
 }
 
 
-void OculusTextureBuffer::SetupMSAA(osg::State& state)
+void OculusTextureBuffer::setupMSAA(osg::State& state)
 {
 	const OSG_GLExtensions* fbo_ext = getGLExtensions(state);
 
@@ -160,8 +169,7 @@ void OculusTextureBuffer::SetupMSAA(osg::State& state)
 	// We don't want to support MIPMAP so, ensure only level 0 is allowed.
 	const int maxTextureLevel = 0;
 
-	const unsigned int contextID = state.getContextID();
-	const osg::Texture::Extensions* extensions = osg::Texture::getExtensions(contextID, true);
+	const OSG_Texture_Extensions* extensions = getTextureExtensions(state);
 
 	// Create MSAA colour buffer
 	glGenTextures(1, &m_MSAA_ColorTex);

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -18,8 +18,10 @@
 
 #if(OSG_VERSION_GREATER_OR_EQUAL(3, 4, 0))
 typedef osg::GLExtensions OSG_GLExtensions;
+typedef osg::GLExtensions OSG_Texture_Extensions;
 #else
 typedef osg::FBOExtensions OSG_GLExtensions;
+typedef osg::Texture::Extensions OSG_Texture_Extensions;
 #endif
 
 class OculusTextureBuffer : public osg::Referenced {
@@ -45,8 +47,8 @@ protected:
 	osg::ref_ptr<osg::Texture2D> m_depthBuffer;
 	osg::Vec2i m_textureSize;
 	
-	void SetupNormal(osg::State& state);
-	void SetupMSAA(osg::State& state);
+	void setup(osg::State& state);
+	void setupMSAA(osg::State& state);
 
 	GLuint m_Oculus_FBO = 0; // MSAA FBO is copied to this FBO after render.
 	GLuint m_MSAA_FBO = 0; // framebuffer for MSAA texture

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -16,55 +16,50 @@
 #include <osg/Version>
 #include <osg/FrameBufferObject>
 
+#if(OSG_VERSION_GREATER_OR_EQUAL(3, 4, 0))
+typedef osg::GLExtensions OSG_GLExtensions;
+#else
+typedef osg::FBOExtensions OSG_GLExtensions;
+#endif
 
 class OculusTextureBuffer : public osg::Referenced {
 public:
-	OculusTextureBuffer(const ovrHmd& hmd, osg::ref_ptr<osg::State> state, const ovrSizei& size);
+	OculusTextureBuffer(const ovrHmd& hmd, osg::ref_ptr<osg::State> state, const ovrSizei& size, int msaaSamples);
 	void destroy();
-	int textureWidth() const { return m_textureSize.x();  }
+	int textureWidth() const { return m_textureSize.x(); }
 	int textureHeight() const { return m_textureSize.y(); }
+	int samples() const { return m_samples; }
 	ovrSwapTextureSet* textureSet() const { return m_textureSet; }
-	osg::ref_ptr<osg::Texture2D> texture() const { return m_texture; }
+	osg::ref_ptr<osg::Texture2D> colorBuffer() const { return m_colorBuffer; }
+	osg::ref_ptr<osg::Texture2D> depthBuffer() const { return m_depthBuffer; }
 	void advanceIndex() { m_textureSet->CurrentIndex = (m_textureSet->CurrentIndex + 1) % m_textureSet->TextureCount; }
-	void setRenderSurface(const osg::State& state);
-	void initializeFboId(GLuint id) { m_fboId = id; m_fboIdInitialized = true; }
-	bool isFboIdInitialized() const { return m_fboIdInitialized; }
+	void onPreRender(osg::RenderInfo& renderInfo);
+	void onPostRender(osg::RenderInfo& renderInfo);
+
 protected:
 	~OculusTextureBuffer() {}
 
 	const ovrHmd m_hmdDevice;
 	ovrSwapTextureSet* m_textureSet;
-	osg::ref_ptr<osg::Texture2D> m_texture;
+	osg::ref_ptr<osg::Texture2D> m_colorBuffer;
+	osg::ref_ptr<osg::Texture2D> m_depthBuffer;
 	osg::Vec2i m_textureSize;
-	GLuint m_fboId;
-	bool m_fboIdInitialized;
+	
+	void SetupNormal(osg::State& state);
+	void SetupMSAA(osg::State& state);
+
+	GLuint m_Oculus_FBO = 0; // MSAA FBO is copied to this FBO after render.
+	GLuint m_MSAA_FBO = 0; // framebuffer for MSAA texture
+	GLuint m_MSAA_ColorTex = 0; // color texture for MSAA
+	GLuint m_MSAA_DepthTex = 0; // depth texture for MSAA
+	int m_samples = 0;  // sample width for MSAA
+
 };
-
-
-class OculusDepthBuffer : public osg::Referenced {
-public:
-	explicit OculusDepthBuffer(const ovrSizei& size, osg::ref_ptr<osg::State> state);
-	void destroy() {};
-	int textureWidth() const { return m_textureSize.x(); }
-	int textureHeight() const { return m_textureSize.y(); }
-	osg::ref_ptr<osg::Texture2D> texture() const { return m_texture; }
-	void setRenderSurface(const osg::State& state);
-protected:
-	~OculusDepthBuffer() {}
-
-	osg::ref_ptr<osg::Texture2D> m_texture;
-	osg::Vec2i m_textureSize;
-};
-
 
 class OculusMirrorTexture : public osg::Referenced {
 public:
 	OculusMirrorTexture(const ovrHmd& hmd, osg::ref_ptr<osg::State> state, int width, int height);
-#if(OSG_VERSION_GREATER_OR_EQUAL(3, 4, 0))
-	void destroy(const osg::GLExtensions* fbo_ext = 0);
-#else
-	void destroy(const osg::FBOExtensions* fbo_ext=0);
-#endif
+	void destroy(const OSG_GLExtensions* fbo_ext = 0);
 	GLuint id() const { return m_texture->OGL.TexId; }
 	GLint width() const { return m_texture->OGL.Header.TextureSize.w; }
 	GLint height() const { return m_texture->OGL.Header.TextureSize.h; }
@@ -81,10 +76,9 @@ protected:
 class OculusPreDrawCallback : public osg::Camera::DrawCallback
 {
 public:
-	OculusPreDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer, OculusDepthBuffer* depthBuffer)
+	OculusPreDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer)
 		: m_camera(camera)
 		, m_textureBuffer(textureBuffer)
-		, m_depthBuffer(depthBuffer)
 	{
 	}
 
@@ -92,7 +86,22 @@ public:
 protected:
 	osg::Camera* m_camera;
 	OculusTextureBuffer* m_textureBuffer;
-	OculusDepthBuffer* m_depthBuffer;
+
+};
+
+class OculusPostDrawCallback : public osg::Camera::DrawCallback
+{
+public:
+	OculusPostDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer)
+		: m_camera(camera)
+		, m_textureBuffer(textureBuffer)
+	{
+	}
+
+	virtual void operator()(osg::RenderInfo& renderInfo) const;
+protected:
+	osg::Camera* m_camera;
+	OculusTextureBuffer* m_textureBuffer;
 
 };
 
@@ -106,7 +115,7 @@ class OculusDevice : public osg::Referenced {
 			RIGHT = 1,
 			COUNT = 2
 		} Eye;
-		OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel = 1.0f, const float worldUnitsPerMetre = 1.0f);
+		OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel = 1.0f, const float worldUnitsPerMetre = 1.0f, const int samples = 0);
 		void createRenderBuffers(osg::ref_ptr<osg::State> state);
 		void init();
 
@@ -163,7 +172,6 @@ class OculusDevice : public osg::Referenced {
 		const float m_worldUnitsPerMetre;
 
 		osg::ref_ptr<OculusTextureBuffer> m_textureBuffer[2];
-		osg::ref_ptr<OculusDepthBuffer> m_depthBuffer[2];
 		osg::ref_ptr<OculusMirrorTexture> m_mirrorTexture;
 		
 		ovrEyeRenderDesc m_eyeRenderDesc[2];
@@ -183,6 +191,7 @@ class OculusDevice : public osg::Referenced {
 
 		float m_nearClip;
 		float m_farClip;
+		int m_samples;
 	private:
 		OculusDevice(const OculusDevice&); // Do not allow copy
 		OculusDevice& operator=(const OculusDevice&); // Do not allow assignment operator.

--- a/src/viewerexample.cpp
+++ b/src/viewerexample.cpp
@@ -46,7 +46,8 @@ int main( int argc, char** argv )
 	float farClip = 10000.0f;
 	float pixelsPerDisplayPixel = 1.0;
 	float worldUnitsPerMetre = 1.0f;
-	osg::ref_ptr<OculusDevice> oculusDevice = new OculusDevice(nearClip, farClip, pixelsPerDisplayPixel, worldUnitsPerMetre);
+	int samples = 4;
+	osg::ref_ptr<OculusDevice> oculusDevice = new OculusDevice(nearClip, farClip, pixelsPerDisplayPixel, worldUnitsPerMetre, samples);
 
 	// Get the suggested context traits
 	osg::ref_ptr<osg::GraphicsContext::Traits> traits = oculusDevice->graphicsContextTraits();


### PR DESCRIPTION
Adds support for MSAA which is enabled by passing a non zero `samples` parameter when creating `OculusDevice` 

I think I have made the changes so that the original behaviour is the same as before when passing in samples = 0