### PR TITLE
Fix crash when no HMD plugged in.

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -304,6 +304,7 @@ void OculusMirrorTexture::destroy(const OSG_GLExtensions* fbo_ext)
 
 /* Public functions */
 OculusDevice::OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel, const float worldUnitsPerMetre, const int samples) :
+	m_hmdDetected(false),
 	m_session(nullptr),
 	m_hmdDesc(),
 	m_pixelsPerDisplayPixel(pixelsPerDisplayPixel),
@@ -337,6 +338,8 @@ OculusDevice::OculusDevice(float nearClip, float farClip, const float pixelsPerD
 		osg::notify(osg::WARN) << "Warning: No device could be found." << std::endl;
 		return;
 	}
+	
+	m_hmdDetected = true;
 
 	// Get HMD description
 	m_hmdDesc = ovr_GetHmdDesc(m_session);
@@ -617,12 +620,18 @@ osg::GraphicsContext::Traits* OculusDevice::graphicsContextTraits() const
 OculusDevice::~OculusDevice()
 {
 	// Delete mirror texture
-	m_mirrorTexture->destroy();
+	if (m_mirrorTexture.valid())
+	{
+		m_mirrorTexture->destroy();
+	}
 
 	// Delete texture and depth buffers
 	for (int i = 0; i < 2; i++)
 	{
-		m_textureBuffer[i]->destroy();
+		if (m_textureBuffer[i].valid())
+		{
+			m_textureBuffer[i]->destroy();
+		}
 	}
 
 	ovr_Destroy(m_session);

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -124,6 +124,8 @@ public:
 	void createRenderBuffers(osg::ref_ptr<osg::State> state);
 	void init();
 
+	bool hmdDetected() const { return m_hmdDetected; }
+
 	unsigned int screenResolutionWidth() const;
 	unsigned int screenResolutionHeight() const;
 
@@ -170,6 +172,7 @@ protected:
 
 	void trySetProcessAsHighPriority() const;
 
+	bool m_hmdDetected;
 	ovrSession m_session;
 	ovrHmdDesc m_hmdDesc;
 

--- a/src/viewerexample.cpp
+++ b/src/viewerexample.cpp
@@ -50,6 +50,11 @@ int main( int argc, char** argv )
 	int samples = 4;
 	osg::ref_ptr<OculusDevice> oculusDevice = new OculusDevice(nearClip, farClip, pixelsPerDisplayPixel, worldUnitsPerMetre, samples);
 
+	if (!oculusDevice->hmdDetected())
+	{
+		return 1;
+	}
+
 	// Get the suggested context traits
 	osg::ref_ptr<osg::GraphicsContext::Traits> traits = oculusDevice->graphicsContextTraits();
 	traits->windowName = "OsgOculusViewerExample";


### PR DESCRIPTION
Since the 0.7.0.0 SDK no longer seems to support creating the debug emulated HMD when no device is present or detected, the viewer crashes because it proceeds without a valid device handle.

This change just allows the viewer to exit more cleanly when no HMD is plugged in.