### PR TITLE
Make OculusDevice position and orientation match the OculusSDK

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -477,9 +477,9 @@ void OculusDevice::updatePose(unsigned int frameIndex)
 	ovr_CalcEyePoses(ts.HeadPose.ThePose, m_viewOffset, m_eyeRenderPose);
 	ovrPoseStatef headpose = ts.HeadPose;
 	ovrPosef pose = headpose.ThePose;
-	m_position.set(-pose.Position.x, -pose.Position.y, -pose.Position.z);
+	m_position.set(pose.Position.x, pose.Position.y, pose.Position.z);
 	m_position *= m_worldUnitsPerMetre;
-	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, -pose.Orientation.w);
+	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, pose.Orientation.w);
 }
 
 void OculusInitialDrawCallback::operator()(osg::RenderInfo& renderInfo) const

--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -10,9 +10,6 @@
 
 #include "oculusdevice.h"
 
-// include oculus extras
-#include <Extras/OVR_Math.h>
-
 #ifdef _WIN32
 	#include <Windows.h>
 #endif
@@ -482,10 +479,6 @@ void OculusDevice::updatePose(unsigned int frameIndex)
 	ovrPosef pose = headpose.ThePose;
 	m_position.set(-pose.Position.x, -pose.Position.y, -pose.Position.z);
 	m_position *= m_worldUnitsPerMetre;
-
-   // store the oculus orientation - needed to request yaw/pitch/roll
-   m_oculusOrientation = pose.Orientation;
-   // convert to osg orientation
 	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, -pose.Orientation.w);
 }
 
@@ -747,15 +740,6 @@ void OculusDevice::trySetProcessAsHighPriority() const
 #endif
 	}
 }
-
-osg::Vec3 OculusDevice::yawPitchRoll() const
-{
-   OVR::Quat<float> ciccio(m_oculusOrientation);
-   float y, p, r;
-   ciccio.GetYawPitchRoll(&y, &p, &r);
-   return osg::Vec3(y, p, r);
-}
-
 
 void OculusRealizeOperation::operator() (osg::GraphicsContext* gc)
 {

--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -10,6 +10,9 @@
 
 #include "oculusdevice.h"
 
+// include oculus extras
+#include <Extras/OVR_Math.h>
+
 #ifdef _WIN32
 	#include <Windows.h>
 #endif
@@ -479,6 +482,10 @@ void OculusDevice::updatePose(unsigned int frameIndex)
 	ovrPosef pose = headpose.ThePose;
 	m_position.set(-pose.Position.x, -pose.Position.y, -pose.Position.z);
 	m_position *= m_worldUnitsPerMetre;
+
+   // store the oculus orientation - needed to request yaw/pitch/roll
+   m_oculusOrientation = pose.Orientation;
+   // convert to osg orientation
 	m_orientation.set(pose.Orientation.x, pose.Orientation.y, pose.Orientation.z, -pose.Orientation.w);
 }
 
@@ -740,6 +747,15 @@ void OculusDevice::trySetProcessAsHighPriority() const
 #endif
 	}
 }
+
+osg::Vec3 OculusDevice::yawPitchRoll() const
+{
+   OVR::Quat<float> ciccio(m_oculusOrientation);
+   float y, p, r;
+   ciccio.GetYawPitchRoll(&y, &p, &r);
+   return osg::Vec3(y, p, r);
+}
+
 
 void OculusRealizeOperation::operator() (osg::GraphicsContext* gc)
 {

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -147,6 +147,7 @@ public:
 
 	osg::Vec3 position() const { return m_position; }
 	osg::Quat orientation() const { return m_orientation;  }
+   osg::Vec3 yawPitchRoll() const;
 
 	osg::Camera* createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, const osg::Vec4& clearColor, osg::GraphicsContext* gc = 0) const;
 
@@ -195,6 +196,10 @@ protected:
 
 	osg::Vec3 m_position;
 	osg::Quat m_orientation;
+
+   // oculus orientation quaternion,
+   // used to extract yaw pitch and roll with oculus routines
+   ovrQuatf m_oculusOrientation;
 
 	float m_nearClip;
 	float m_farClip;

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -147,7 +147,6 @@ public:
 
 	osg::Vec3 position() const { return m_position; }
 	osg::Quat orientation() const { return m_orientation;  }
-   osg::Vec3 yawPitchRoll() const;
 
 	osg::Camera* createRTTCamera(OculusDevice::Eye eye, osg::Transform::ReferenceFrame referenceFrame, const osg::Vec4& clearColor, osg::GraphicsContext* gc = 0) const;
 
@@ -196,10 +195,6 @@ protected:
 
 	osg::Vec3 m_position;
 	osg::Quat m_orientation;
-
-   // oculus orientation quaternion,
-   // used to extract yaw pitch and roll with oculus routines
-   ovrQuatf m_oculusOrientation;
 
 	float m_nearClip;
 	float m_farClip;

--- a/src/oculusupdateslavecallback.cpp
+++ b/src/oculusupdateslavecallback.cpp
@@ -19,8 +19,10 @@ void OculusUpdateSlaveCallback::updateSlave(osg::View& view, osg::View::Slave& s
 
 	osg::Matrix viewOffset = (m_cameraType == LEFT_CAMERA) ? m_device->viewMatrixLeft() : m_device->viewMatrixRight();
 
+   // invert orientation and position to apply to the view matrix as offset
+   orientation[3] *= -1.f;
 	viewOffset.preMultRotate(orientation);
-	viewOffset.preMultTranslate(position);
+	viewOffset.preMultTranslate(-position);
 
 	slave._viewOffset = viewOffset;
 


### PR DESCRIPTION
Hi Bjorn, 

this pull request adds a method to get Oculus orientation as yaw, pitch and roll, using internal Oculus math.
It can be useful when integrating the Oculus in more complex applications where you need to know the current camera offset given by the tracker, to use it for motion, selection, etc.

I've tested the method in my own project and works as expected.
The guideline explaining the yaw, pitch roll reference is here:
https://developer.oculus.com/documentation/pcsdk/latest/concepts/dg-sensor/#dg-sensor-head-tracking


