### PR TITLE
Exposed parameter to the the mirror texture size

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -303,12 +303,13 @@ void OculusMirrorTexture::destroy(const OSG_GLExtensions* fbo_ext)
 }
 
 /* Public functions */
-OculusDevice::OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel, const float worldUnitsPerMetre, const int samples) :
+OculusDevice::OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel, const float worldUnitsPerMetre, const int samples, unsigned int mirrorTextureWidth) :
 	m_session(nullptr),
 	m_hmdDesc(),
 	m_pixelsPerDisplayPixel(pixelsPerDisplayPixel),
 	m_worldUnitsPerMetre(worldUnitsPerMetre),
 	m_mirrorTexture(nullptr),
+   m_mirrorTextureWidth(mirrorTextureWidth),
 	m_position(osg::Vec3(0.0f, 0.0f, 0.0f)),
 	m_orientation(osg::Quat(0.0f, 0.0f, 0.0f, 1.0f)),
 	m_nearClip(nearClip), m_farClip(farClip),
@@ -358,10 +359,10 @@ void OculusDevice::createRenderBuffers(osg::ref_ptr<osg::State> state)
 		ovrSizei recommenedTextureSize = ovr_GetFovTextureSize(m_session, (ovrEyeType)i, m_hmdDesc.DefaultEyeFov[i], m_pixelsPerDisplayPixel);
 		m_textureBuffer[i] = new OculusTextureBuffer(m_session, state, recommenedTextureSize, m_samples);
 	}
-
-	int width = screenResolutionWidth() / 2;
-	int height = screenResolutionHeight() / 2;
-	m_mirrorTexture = new OculusMirrorTexture(m_session, state, width, height);
+   
+   // compute mirror texture height based on requested with and respecting the Oculus screen ar
+   int height = (float)m_mirrorTextureWidth / (float)screenResolutionWidth() * (float)screenResolutionHeight();
+	m_mirrorTexture = new OculusMirrorTexture(m_session, state, m_mirrorTextureWidth, height);
 }
 
 void OculusDevice::init()
@@ -624,8 +625,8 @@ osg::GraphicsContext::Traits* OculusDevice::graphicsContextTraits() const
 	traits->windowDecoration = true;
 	traits->x = 50;
 	traits->y = 50;
-	traits->width = screenResolutionWidth() / 2;
-	traits->height = screenResolutionHeight() / 2;
+   traits->width = m_mirrorTextureWidth;
+   traits->height = (float)m_mirrorTextureWidth / (float)screenResolutionWidth() * (float)screenResolutionHeight();
 	traits->doubleBuffer = true;
 	traits->sharedContext = nullptr;
 	traits->vsync = false; // VSync should always be disabled for Oculus Rift applications, the SDK compositor handles the swap

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -120,7 +120,7 @@ public:
 		RIGHT = 1,
 		COUNT = 2
 	} Eye;
-	OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel = 1.0f, const float worldUnitsPerMetre = 1.0f, const int samples = 0);
+	OculusDevice(float nearClip, float farClip, const float pixelsPerDisplayPixel = 1.0f, const float worldUnitsPerMetre = 1.0f, const int samples = 0, unsigned int mirrorTextureWidth = 960);
 	void createRenderBuffers(osg::ref_ptr<osg::State> state);
 	void init();
 
@@ -180,6 +180,8 @@ protected:
 
 	osg::ref_ptr<OculusTextureBuffer> m_textureBuffer[2];
 	osg::ref_ptr<OculusMirrorTexture> m_mirrorTexture;
+
+   unsigned int m_mirrorTextureWidth;
 
 	ovrEyeRenderDesc m_eyeRenderDesc[2];
 	ovrVector2f m_UVScaleOffset[2][2];


### PR DESCRIPTION
Width expressed in pixels, height computes according to the Oculus screen aspect ratio.
Default value set to 960 to keep current settings (1920 / 2).