### PR TITLE
Explicitly realize the viewer and call setReleaseContextAtEndOfFrameHint(false)

### DIFF
--- a/src/oculusviewer.cpp
+++ b/src/oculusviewer.cpp
@@ -26,13 +26,13 @@ void OculusViewer::traverse(osg::NodeVisitor& nv)
 /* Protected functions */
 void OculusViewer::configure()
 {
-	osg::ref_ptr<osg::GraphicsContext> gc =  m_view->getCamera()->getGraphicsContext();
+	osg::ref_ptr<osg::GraphicsContext> gc =  m_viewer->getCamera()->getGraphicsContext();
 
 	// Attach a callback to detect swap
 	osg::ref_ptr<OculusSwapCallback> swapCallback = new OculusSwapCallback(m_device);
 	gc->setSwapCallback(swapCallback.get());
 
-	osg::ref_ptr<osg::Camera> camera = m_view->getCamera();
+	osg::ref_ptr<osg::Camera> camera = m_viewer->getCamera();
 	camera->setName("Main");
 	osg::Vec4 clearColor = camera->getClearColor();
 
@@ -43,20 +43,24 @@ void OculusViewer::configure()
 	cameraRTTRight->setName("RightRTT");
 
 	// Add RTT cameras as slaves, specifying offsets for the projection
-	m_view->addSlave(cameraRTTLeft,
+   m_viewer->addSlave(cameraRTTLeft,
 					 m_device->projectionMatrix(OculusDevice::Eye::LEFT),
 					 m_device->viewMatrix(OculusDevice::Eye::LEFT),
 					 true);
-	m_view->getSlave(0)._updateSlaveCallback = new OculusUpdateSlaveCallback(OculusUpdateSlaveCallback::LEFT_CAMERA, m_device.get(), swapCallback.get());
+   m_viewer->getSlave(0)._updateSlaveCallback = new OculusUpdateSlaveCallback(OculusUpdateSlaveCallback::LEFT_CAMERA, m_device.get(), swapCallback.get());
 
-	m_view->addSlave(cameraRTTRight,
+   m_viewer->addSlave(cameraRTTRight,
 					m_device->projectionMatrix(OculusDevice::Eye::RIGHT),
 					m_device->viewMatrix(OculusDevice::Eye::RIGHT),
 					 true);
-	m_view->getSlave(1)._updateSlaveCallback = new OculusUpdateSlaveCallback(OculusUpdateSlaveCallback::RIGHT_CAMERA, m_device.get(), swapCallback.get());
+   m_viewer->getSlave(1)._updateSlaveCallback = new OculusUpdateSlaveCallback(OculusUpdateSlaveCallback::RIGHT_CAMERA, m_device.get(), swapCallback.get());
 
 	// Use sky light instead of headlight to avoid light changes when head movements
-	m_view->setLightingMode(osg::View::SKY_LIGHT);
+   m_viewer->setLightingMode(osg::View::SKY_LIGHT);
+
+   // this flag needs to be set to avoid the following GL warning at every frame:
+   // Warning: detected OpenGL error 'invalid operation' at after RenderBin::draw(..)
+   m_viewer->setReleaseContextAtEndOfFrameHint(false);
 
 	// Disable rendering of main camera since its being overwritten by the swap texture anyway
 	camera->setGraphicsContext(nullptr);

--- a/src/oculusviewer.h
+++ b/src/oculusviewer.h
@@ -9,6 +9,7 @@
 #define _OSG_OCULUSVIEWER_H_
 
 #include <osg/Group>
+#include <osgViewer/Viewer>
 
 #include "oculusdevice.h"
 
@@ -22,9 +23,9 @@ namespace osgViewer
 class OculusViewer : public osg::Group
 {
 public:
-	OculusViewer(osgViewer::View* view, osg::ref_ptr<OculusDevice> dev, osg::ref_ptr<OculusRealizeOperation> realizeOperation) : osg::Group(),
+	OculusViewer(osgViewer::Viewer* viewer, osg::ref_ptr<OculusDevice> dev, osg::ref_ptr<OculusRealizeOperation> realizeOperation) : osg::Group(),
 		m_configured(false),
-		m_view(view),
+		m_viewer(viewer),
 		m_device(dev),
 		m_realizeOperation(realizeOperation)
 	{};
@@ -35,7 +36,7 @@ protected:
 
 	bool m_configured;
 
-	osg::observer_ptr<osgViewer::View> m_view;
+	osg::observer_ptr<osgViewer::Viewer> m_viewer;
 	osg::observer_ptr<OculusDevice> m_device;
 	osg::observer_ptr<OculusRealizeOperation> m_realizeOperation;
 };

--- a/src/viewerexample.cpp
+++ b/src/viewerexample.cpp
@@ -99,14 +99,7 @@ int main( int argc, char** argv )
 
 	viewer.addEventHandler(new OculusEventHandler(oculusDevice));
 
-   // realize the viewer
-   viewer.realize();
-   // this call is needed to avoid the following warning message at every frame:
-   // Warning: detected OpenGL error 'invalid operation' at after RenderBin::draw(..)
-   viewer.setReleaseContextAtEndOfFrameHint(false);
-
-   while (!viewer.done())
-      viewer.frame();
+	viewer.run();
 
 	return 0;
 }

--- a/src/viewerexample.cpp
+++ b/src/viewerexample.cpp
@@ -99,7 +99,14 @@ int main( int argc, char** argv )
 
 	viewer.addEventHandler(new OculusEventHandler(oculusDevice));
 
-	viewer.run();
+   // realize the viewer
+   viewer.realize();
+   // this call is needed to avoid the following warning message at every frame:
+   // Warning: detected OpenGL error 'invalid operation' at after RenderBin::draw(..)
+   viewer.setReleaseContextAtEndOfFrameHint(false);
+
+   while (!viewer.done())
+      viewer.frame();
 
 	return 0;
 }


### PR DESCRIPTION
Hi @bjornblissing 

I suggest the following change to the OculusViewerExample to stress that it's mandatory to call 
```setReleaseContextAtEndOfFrameHint(false)```
in order not to get a GL warning message at every frame during the execution.
It was hard for me to track down where the warning was coming from in my application, because the method viewer.run() "hides" this initialization, so I think it's best to make it explicit.
I'm using osg 3.6.3 and Oculus SDK 1.30