### PR TITLE
update tracking poses

### DIFF
--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -147,6 +147,7 @@ void OculusDevice::updatePose(long long frameIndex)
 
    // update touch pose
    ovrTrackingState trackingState = ovr_GetTrackingState(m_session, 0.0, false);
+	m_headPose = trackingState.HeadPose;
    m_handPoses[ovrHand_Left] = trackingState.HandPoses[ovrHand_Left];
    m_handPoses[ovrHand_Right] = trackingState.HandPoses[ovrHand_Right];
 }

--- a/src/oculusdevice.cpp
+++ b/src/oculusdevice.cpp
@@ -144,6 +144,11 @@ void OculusDevice::updatePose(long long frameIndex)
 
 	// Update touch controllers
 	ovr_GetInputState(m_session, ovrControllerType_Touch, &m_controllerState);
+
+   // update touch pose
+   ovrTrackingState trackingState = ovr_GetTrackingState(m_session, 0.0, false);
+   m_handPoses[ovrHand_Left] = trackingState.HandPoses[ovrHand_Left];
+   m_handPoses[ovrHand_Right] = trackingState.HandPoses[ovrHand_Right];
 }
 
 osg::Vec3 OculusDevice::position(Eye eye) const {

--- a/src/oculusdevice.h
+++ b/src/oculusdevice.h
@@ -63,6 +63,7 @@ public:
 	bool touchControllerAvailable() const;
 	ovrInputState touchControllerState() const { return m_controllerState; }
 
+	ovrPoseStatef headPose() const { return m_headPose; }
 	ovrPoseStatef handPoseLeft() const { return m_handPoses[ovrHand_Left]; }
 	ovrPoseStatef handPoseRigth() const { return m_handPoses[ovrHand_Right]; }
 
@@ -84,6 +85,7 @@ protected:
 	ovrHmdDesc m_hmdDesc;
 	ovrInputState m_controllerState;
 	ovrPoseStatef m_handPoses[2];
+	ovrPoseStatef m_headPose;
 
 	const float m_pixelsPerDisplayPixel;
 	const float m_worldUnitsPerMetre;


### PR DESCRIPTION
Hi @bjornblissing 
please find a first draft of a PR to update tracking state of the touch controllers (m_handPoses member variable was already there but never updated).

Next I'll also need to get the Head Pose, which is part of the ovrTrackingState data structure.
I'm wondering whether is best to add another member variable for the head pose, or simply have a ovrTrackingState member variable and adding an accessor to it, similarly to the approach taken for m_controllerState

