### PR TITLE
Added option to blit on camera PostDraw

### DIFF
--- a/include/oculusdevice.h
+++ b/include/oculusdevice.h
@@ -30,7 +30,9 @@ class OculusDevice : public osg::Referenced {
                const float worldUnitsPerMetre,
                const int samples,
                TrackingOrigin origin,
-               const int mirrorTextureWidth);
+               const int mirrorTextureWidth,
+               bool blitOnPostDraw = false);
+
   void createRenderBuffers(osg::State* state);
   void init();
 
@@ -51,6 +53,10 @@ class OculusDevice : public osg::Referenced {
     return m_farClip;
   }
 
+  bool blitOnPostDraw() const {
+    return m_blitOnPostDraw;
+  }
+
   void resetSensorOrientation() const {
     ovr_RecenterTrackingOrigin(m_session);
   }
@@ -67,7 +73,7 @@ class OculusDevice : public osg::Referenced {
   osg::Camera* createRTTCamera(OculusDevice::Eye eye,
                                osg::Transform::ReferenceFrame referenceFrame,
                                const osg::Vec4& clearColor,
-                               osg::GraphicsContext* gc = 0) const;
+                               osg::GraphicsContext* gc = 0);
 
   bool waitToBeginFrame(long long frameIndex = 0);
   bool beginFrame(long long frameIndex = 0);
@@ -140,6 +146,8 @@ class OculusDevice : public osg::Referenced {
   int m_samples = {0};
   bool m_begunFrame = {false};
   TrackingOrigin m_origin;
+
+  bool m_blitOnPostDraw = false;
 };
 
 #endif /* _OSG_OCULUSDEVICE_H_ */

--- a/include/oculusdrawcallbacks.h
+++ b/include/oculusdrawcallbacks.h
@@ -12,6 +12,7 @@
 
 // Forward declaration
 class OculusTextureBuffer;
+class OculusDevice;
 
 class OculusInitialDrawCallback : public osg::Camera::DrawCallback {
  public:
@@ -33,15 +34,15 @@ class OculusPreDrawCallback : public osg::Camera::DrawCallback {
 
 class OculusPostDrawCallback : public osg::Camera::DrawCallback {
  public:
-  OculusPostDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer) :
-      m_camera(camera),
-      m_textureBuffer(textureBuffer) {}
+  OculusPostDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer, bool blit = false, OculusDevice* device = nullptr);
 
   void operator()(osg::RenderInfo& renderInfo) const override;
 
  private:
   osg::observer_ptr<osg::Camera> m_camera;
   osg::observer_ptr<OculusTextureBuffer> m_textureBuffer;
+  bool m_blit;
+  osg::observer_ptr<OculusDevice> m_device;
 };
 
 #endif /* _OSG_OCULUSDRAWCALLBACKS_H_ */

--- a/src/oculusdrawcallbacks.cpp
+++ b/src/oculusdrawcallbacks.cpp
@@ -6,8 +6,10 @@
  */
 #include <osgViewer/Renderer>
 
+#include <oculusdevice.h>
 #include <oculusdrawcallbacks.h>
 #include <oculustexturebuffer.h>
+
 
 void OculusInitialDrawCallback::operator()(osg::RenderInfo& renderInfo) const {
   osg::GraphicsOperation* graphicsOperation = renderInfo.getCurrentCamera()->getRenderer();
@@ -22,6 +24,17 @@ void OculusPreDrawCallback::operator()(osg::RenderInfo& renderInfo) const {
   m_textureBuffer->onPreRender(renderInfo);
 }
 
+ OculusPostDrawCallback::OculusPostDrawCallback(osg::Camera* camera, OculusTextureBuffer* textureBuffer, bool blit /*= false*/, OculusDevice* device /*= nullptr*/) :
+      m_camera(camera),
+      m_textureBuffer(textureBuffer),
+      m_blit(blit),
+      m_device(device)
+{
+
+}
+
 void OculusPostDrawCallback::operator()(osg::RenderInfo& renderInfo) const {
   m_textureBuffer->onPostRender(renderInfo);
+  if (m_blit)
+     m_device->blitMirrorTexture(m_camera->getGraphicsContext());
 }

--- a/src/oculusswapcallback.cpp
+++ b/src/oculusswapcallback.cpp
@@ -12,8 +12,10 @@ void OculusSwapCallback::swapBuffersImplementation(osg::GraphicsContext* gc) {
   // Submit rendered frame to compositor
   m_device->submitFrame(m_frameIndex++);
 
-  // Blit mirror texture to backbuffer
-  m_device->blitMirrorTexture(gc);
+  // Blit mirror texture to backbuffer, 
+  // if not already doing the blit on post draw
+  if (!m_device->blitOnPostDraw())
+    m_device->blitMirrorTexture(gc);
 
   // Run the default system swapBufferImplementation
   gc->swapBuffersImplementation();

--- a/src/viewerexample.cpp
+++ b/src/viewerexample.cpp
@@ -48,7 +48,8 @@ int main(int argc, char** argv) {
                                                              worldUnitsPerMetre,
                                                              samples,
                                                              origin,
-                                                             mirrorTextureWidth);
+                                                             mirrorTextureWidth,
+                                                             false);
 
   // Exit if we do not have a valid HMD present
   if (!oculusDevice->hmdPresent()) {


### PR DESCRIPTION
Added the option to blit the mirror camera on the Oculus Right eye camera PostDraw callback rather than swap callback. 
This allows other cameras rendering in POST to draw after the texture blit, allowing for instance to visualize osg stats.

See attached image for the OsgOculusViewerExample with the stats enabled (I think the huge update time is just due to the viewer waiting for the next swap buffer, saturated at 80Hz by the Oculus SDK).

![image](https://user-images.githubusercontent.com/2272034/103230252-408cdd80-4935-11eb-9bd6-eb71e208a309.png)
